### PR TITLE
Move from Javax JSON to Jakarta JSON

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -48,7 +48,7 @@ If you are using Maven:
   <dependency>
     <groupId>eu.mulk.quarkus-googlecloud-jsonlogging</groupId>
     <artifactId>quarkus-googlecloud-jsonlogging</artifactId>
-    <version>5.0.0</version>
+    <version>6.0.0</version>
   </dependency>
 
 </dependencies>
@@ -59,7 +59,7 @@ If you are using Gradle:
 [source,groovy]
 ----
 dependencies {
-  implementation("eu.mulk.quarkus-googlecloud-jsonlogging:quarkus-googlecloud-jsonlogging:5.0.0")
+  implementation("eu.mulk.quarkus-googlecloud-jsonlogging:quarkus-googlecloud-jsonlogging:6.0.0")
 }
 ----
 
@@ -90,7 +90,7 @@ If you are using Maven:
   <dependency>
     <groupId>eu.mulk.quarkus-googlecloud-jsonlogging</groupId>
     <artifactId>quarkus-googlecloud-jsonlogging-core</artifactId>
-    <version>5.0.0</version>
+    <version>6.0.0</version>
   </dependency>
 
 </dependencies>
@@ -101,7 +101,7 @@ If you are using Gradle:
 [source,groovy]
 ----
 dependencies {
-  implementation("eu.mulk.quarkus-googlecloud-jsonlogging:quarkus-googlecloud-jsonlogging-core:5.0.0")
+  implementation("eu.mulk.quarkus-googlecloud-jsonlogging:quarkus-googlecloud-jsonlogging-core:6.0.0")
 }
 ----
 
@@ -121,7 +121,7 @@ JBoss Log Manager as the back end for SLF4J:
   <dependency>
     <groupId>eu.mulk.quarkus-googlecloud-jsonlogging</groupId>
     <artifactId>quarkus-googlecloud-jsonlogging-core</artifactId>
-    <version>5.0.0</version>
+    <version>6.0.0</version>
   </dependency>
 
   <dependency>
@@ -178,28 +178,28 @@ Logging unstructured data requires no code changes. All logs are
 automatically converted to Google-Cloud-Logging-compatible JSON.
 
 Structured data can be logged in one of 3 different ways: by passing
-https://javadocs.dev/eu.mulk.quarkus-googlecloud-jsonlogging/quarkus-googlecloud-jsonlogging-core/5.0.0/eu.mulk.quarkus.googlecloud.jsonlogging.core/eu/mulk/quarkus/googlecloud/jsonlogging/Label.html[Label]s
+https://javadocs.dev/eu.mulk.quarkus-googlecloud-jsonlogging/quarkus-googlecloud-jsonlogging-core/6.0.0/eu.mulk.quarkus.googlecloud.jsonlogging.core/eu/mulk/quarkus/googlecloud/jsonlogging/Label.html[Label]s
 and
-https://javadocs.dev/eu.mulk.quarkus-googlecloud-jsonlogging/quarkus-googlecloud-jsonlogging-core/5.0.0/eu.mulk.quarkus.googlecloud.jsonlogging.core/eu/mulk/quarkus/googlecloud/jsonlogging/StructuredParameter.html[StructuredParameter]s
+https://javadocs.dev/eu.mulk.quarkus-googlecloud-jsonlogging/quarkus-googlecloud-jsonlogging-core/6.0.0/eu.mulk.quarkus.googlecloud.jsonlogging.core/eu/mulk/quarkus/googlecloud/jsonlogging/StructuredParameter.html[StructuredParameter]s
 as parameters to individual log entries, by supplying
-https://javadocs.dev/eu.mulk.quarkus-googlecloud-jsonlogging/quarkus-googlecloud-jsonlogging-core/5.0.0/eu.mulk.quarkus.googlecloud.jsonlogging.core/eu/mulk/quarkus/googlecloud/jsonlogging/LabelProvider.html[LabelProvider]s
+https://javadocs.dev/eu.mulk.quarkus-googlecloud-jsonlogging/quarkus-googlecloud-jsonlogging-core/6.0.0/eu.mulk.quarkus.googlecloud.jsonlogging.core/eu/mulk/quarkus/googlecloud/jsonlogging/LabelProvider.html[LabelProvider]s
 and
-https://javadocs.dev/eu.mulk.quarkus-googlecloud-jsonlogging/quarkus-googlecloud-jsonlogging-core/5.0.0/eu.mulk.quarkus.googlecloud.jsonlogging.core/eu/mulk/quarkus/googlecloud/jsonlogging/StructuredParameterProvider.html[StructuredParameterProvider]s,
+https://javadocs.dev/eu.mulk.quarkus-googlecloud-jsonlogging/quarkus-googlecloud-jsonlogging-core/6.0.0/eu.mulk.quarkus.googlecloud.jsonlogging.core/eu/mulk/quarkus/googlecloud/jsonlogging/StructuredParameterProvider.html[StructuredParameterProvider]s,
 or by using the Mapped Diagnostic Context.
 
 
 === Using Label and StructuredParameter
 
 Instances of
-https://javadocs.dev/eu.mulk.quarkus-googlecloud-jsonlogging/quarkus-googlecloud-jsonlogging-core/5.0.0/eu.mulk.quarkus.googlecloud.jsonlogging.core/eu/mulk/quarkus/googlecloud/jsonlogging/Label.html[Label]
+https://javadocs.dev/eu.mulk.quarkus-googlecloud-jsonlogging/quarkus-googlecloud-jsonlogging-core/6.0.0/eu.mulk.quarkus.googlecloud.jsonlogging.core/eu/mulk/quarkus/googlecloud/jsonlogging/Label.html[Label]
 and
-https://javadocs.dev/eu.mulk.quarkus-googlecloud-jsonlogging/quarkus-googlecloud-jsonlogging-core/5.0.0/eu.mulk.quarkus.googlecloud.jsonlogging.core/eu/mulk/quarkus/googlecloud/jsonlogging/StructuredParameter.html[StructuredParameter]
+https://javadocs.dev/eu.mulk.quarkus-googlecloud-jsonlogging/quarkus-googlecloud-jsonlogging-core/6.0.0/eu.mulk.quarkus.googlecloud.jsonlogging.core/eu/mulk/quarkus/googlecloud/jsonlogging/StructuredParameter.html[StructuredParameter]
 can be passed as log parameters to the `*f` family of logging
 functions on JBoss Logging's
 https://docs.jboss.org/jbosslogging/latest/org/jboss/logging/Logger.html[Logger].
 
 Simple key–value pairs are represented by
-https://javadocs.dev/eu.mulk.quarkus-googlecloud-jsonlogging/quarkus-googlecloud-jsonlogging-core/5.0.0/eu.mulk.quarkus.googlecloud.jsonlogging.core/eu/mulk/quarkus/googlecloud/jsonlogging/KeyValueParameter.html[KeyValueParameter].
+https://javadocs.dev/eu.mulk.quarkus-googlecloud-jsonlogging/quarkus-googlecloud-jsonlogging-core/6.0.0/eu.mulk.quarkus.googlecloud.jsonlogging.core/eu/mulk/quarkus/googlecloud/jsonlogging/KeyValueParameter.html[KeyValueParameter].
 
 **Example:**
 
@@ -234,9 +234,9 @@ Result:
 === Using LabelProvider and StructuredParameterProvider
 
 Any CDI beans that implement
-https://javadocs.dev/eu.mulk.quarkus-googlecloud-jsonlogging/quarkus-googlecloud-jsonlogging-core/5.0.0/eu.mulk.quarkus.googlecloud.jsonlogging.core/eu/mulk/quarkus/googlecloud/jsonlogging/LabelProvider.html[LabelProvider]
+https://javadocs.dev/eu.mulk.quarkus-googlecloud-jsonlogging/quarkus-googlecloud-jsonlogging-core/6.0.0/eu.mulk.quarkus.googlecloud.jsonlogging.core/eu/mulk/quarkus/googlecloud/jsonlogging/LabelProvider.html[LabelProvider]
 and
-https://javadocs.dev/eu.mulk.quarkus-googlecloud-jsonlogging/quarkus-googlecloud-jsonlogging-core/5.0.0/eu.mulk.quarkus.googlecloud.jsonlogging.core/eu/mulk/quarkus/googlecloud/jsonlogging/StructuredParameterProvider.html[StructuredParameterProvider]
+https://javadocs.dev/eu.mulk.quarkus-googlecloud-jsonlogging/quarkus-googlecloud-jsonlogging-core/6.0.0/eu.mulk.quarkus.googlecloud.jsonlogging.core/eu/mulk/quarkus/googlecloud/jsonlogging/StructuredParameterProvider.html[StructuredParameterProvider]
 are discovered at build time and consulted to provide labels and
 parameters for each message that is logged.  This can be used to
 provide contextual information such as tracing and request IDs stored

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -14,7 +14,7 @@ SPDX-License-Identifier: LGPL-3.0-or-later
   <parent>
     <groupId>eu.mulk.quarkus-googlecloud-jsonlogging</groupId>
     <artifactId>quarkus-googlecloud-jsonlogging-parent</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>6.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>quarkus-googlecloud-jsonlogging-core</artifactId>
@@ -30,8 +30,8 @@ SPDX-License-Identifier: LGPL-3.0-or-later
       <artifactId>smallrye-common-constraint</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.glassfish</groupId>
-      <artifactId>jakarta.json</artifactId>
+      <groupId>jakarta.json</groupId>
+      <artifactId>jakarta.json-api</artifactId>
     </dependency>
   </dependencies>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -14,7 +14,7 @@ SPDX-License-Identifier: LGPL-3.0-or-later
   <parent>
     <groupId>eu.mulk.quarkus-googlecloud-jsonlogging</groupId>
     <artifactId>quarkus-googlecloud-jsonlogging-parent</artifactId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>quarkus-googlecloud-jsonlogging-core</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -30,8 +30,8 @@ SPDX-License-Identifier: LGPL-3.0-or-later
       <artifactId>smallrye-common-constraint</artifactId>
     </dependency>
     <dependency>
-      <groupId>jakarta.json</groupId>
-      <artifactId>jakarta.json-api</artifactId>
+      <groupId>org.eclipse.parsson</groupId>
+      <artifactId>parsson</artifactId>
     </dependency>
   </dependencies>
 

--- a/core/src/main/java/eu/mulk/quarkus/googlecloud/jsonlogging/KeyValueParameter.java
+++ b/core/src/main/java/eu/mulk/quarkus/googlecloud/jsonlogging/KeyValueParameter.java
@@ -7,9 +7,9 @@ package eu.mulk.quarkus.googlecloud.jsonlogging;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Objects;
-import javax.json.Json;
-import javax.json.JsonObjectBuilder;
-import javax.json.JsonValue;
+import jakarta.json.Json;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonValue;
 
 /**
  * A simple single key–value pair forming a {@link StructuredParameter}.

--- a/core/src/main/java/eu/mulk/quarkus/googlecloud/jsonlogging/LogEntry.java
+++ b/core/src/main/java/eu/mulk/quarkus/googlecloud/jsonlogging/LogEntry.java
@@ -8,9 +8,9 @@ import io.smallrye.common.constraint.Nullable;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
-import javax.json.Json;
-import javax.json.JsonObject;
-import javax.json.JsonObjectBuilder;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
 
 /**
  * A JSON log entry compatible with Google Cloud Logging.

--- a/core/src/main/java/eu/mulk/quarkus/googlecloud/jsonlogging/StructuredParameter.java
+++ b/core/src/main/java/eu/mulk/quarkus/googlecloud/jsonlogging/StructuredParameter.java
@@ -4,7 +4,7 @@
 
 package eu.mulk.quarkus.googlecloud.jsonlogging;
 
-import javax.json.JsonObjectBuilder;
+import jakarta.json.JsonObjectBuilder;
 
 /**
  * A structured parameter usable as logging payload.

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -14,7 +14,7 @@ SPDX-License-Identifier: LGPL-3.0-or-later
   <parent>
     <groupId>eu.mulk.quarkus-googlecloud-jsonlogging</groupId>
     <artifactId>quarkus-googlecloud-jsonlogging-parent</artifactId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>quarkus-googlecloud-jsonlogging-deployment</artifactId>

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -14,7 +14,7 @@ SPDX-License-Identifier: LGPL-3.0-or-later
   <parent>
     <groupId>eu.mulk.quarkus-googlecloud-jsonlogging</groupId>
     <artifactId>quarkus-googlecloud-jsonlogging-parent</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>6.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>quarkus-googlecloud-jsonlogging-deployment</artifactId>

--- a/examples/quarkus/pom.xml
+++ b/examples/quarkus/pom.xml
@@ -14,7 +14,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
   <parent>
     <groupId>eu.mulk.quarkus-googlecloud-jsonlogging</groupId>
     <artifactId>quarkus-googlecloud-jsonlogging-parent</artifactId>
-    <version>5.0.0</version>
+    <version>6.0.0</version>
   </parent>
 
   <artifactId>quarkus-googlecloud-jsonlogging-quarkus-example</artifactId>

--- a/examples/quarkus/src/main/java/eu/mulk/quarkus/googlecloud/jsonlogging/example/RandomNumberParameterProvider.java
+++ b/examples/quarkus/src/main/java/eu/mulk/quarkus/googlecloud/jsonlogging/example/RandomNumberParameterProvider.java
@@ -8,8 +8,8 @@ import eu.mulk.quarkus.googlecloud.jsonlogging.KeyValueParameter;
 import eu.mulk.quarkus.googlecloud.jsonlogging.StructuredParameter;
 import eu.mulk.quarkus.googlecloud.jsonlogging.StructuredParameterProvider;
 import io.quarkus.arc.Unremovable;
+import jakarta.inject.Singleton;
 import java.util.concurrent.ThreadLocalRandom;
-import javax.inject.Singleton;
 
 @Singleton
 @Unremovable

--- a/examples/quarkus/src/main/java/eu/mulk/quarkus/googlecloud/jsonlogging/example/RootResource.java
+++ b/examples/quarkus/src/main/java/eu/mulk/quarkus/googlecloud/jsonlogging/example/RootResource.java
@@ -6,11 +6,11 @@ package eu.mulk.quarkus.googlecloud.jsonlogging.example;
 
 import eu.mulk.quarkus.googlecloud.jsonlogging.KeyValueParameter;
 import eu.mulk.quarkus.googlecloud.jsonlogging.Label;
-import javax.annotation.PostConstruct;
-import javax.enterprise.context.ApplicationScoped;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
 import org.jboss.logging.Logger;
 import org.jboss.logging.MDC;
 

--- a/examples/spring-boot/pom.xml
+++ b/examples/spring-boot/pom.xml
@@ -16,7 +16,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
   <parent>
     <groupId>eu.mulk.quarkus-googlecloud-jsonlogging</groupId>
     <artifactId>quarkus-googlecloud-jsonlogging-parent</artifactId>
-    <version>5.0.0</version>
+    <version>6.0.0</version>
   </parent>
 
   <artifactId>quarkus-googlecloud-jsonlogging-spring-boot-example</artifactId>

--- a/examples/spring-boot/pom.xml
+++ b/examples/spring-boot/pom.xml
@@ -23,7 +23,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
   <name>Quarkus Google Cloud JSON Logging Extension - Spring Boot Example</name>
 
   <properties>
-    <spring-boot.version>2.7.3</spring-boot.version>
+    <spring-boot.version>3.0.4</spring-boot.version>
   </properties>
 
   <dependencyManagement>

--- a/examples/spring-boot/src/main/java/eu/mulk/quarkus/googlecloud/jsonlogging/example/RootResource.java
+++ b/examples/spring-boot/src/main/java/eu/mulk/quarkus/googlecloud/jsonlogging/example/RootResource.java
@@ -6,7 +6,7 @@ package eu.mulk.quarkus.googlecloud.jsonlogging.example;
 
 import eu.mulk.quarkus.googlecloud.jsonlogging.KeyValueParameter;
 import eu.mulk.quarkus.googlecloud.jsonlogging.Label;
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import org.jboss.logging.Logger;
 import org.jboss.logging.MDC;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ SPDX-License-Identifier: LGPL-3.0-or-later
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>eu.mulk.quarkus-googlecloud-jsonlogging</groupId>
-  <version>6.0.1-SNAPSHOT</version>
+  <version>6.0.0-SNAPSHOT</version>
 
   <artifactId>quarkus-googlecloud-jsonlogging-parent</artifactId>
   <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ SPDX-License-Identifier: LGPL-3.0-or-later
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>eu.mulk.quarkus-googlecloud-jsonlogging</groupId>
-  <version>5.0.1-SNAPSHOT</version>
+  <version>6.0.1-SNAPSHOT</version>
 
   <artifactId>quarkus-googlecloud-jsonlogging-parent</artifactId>
   <packaging>pom</packaging>
@@ -72,7 +72,7 @@ SPDX-License-Identifier: LGPL-3.0-or-later
     <spotless-plugin.version>2.29.0</spotless-plugin.version>
     <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
 
-    <quarkus.version>2.15.1.Final</quarkus.version>
+    <quarkus.version>3.0.0.Beta1</quarkus.version>
   </properties>
 
   <distributionManagement>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -14,7 +14,7 @@ SPDX-License-Identifier: LGPL-3.0-or-later
   <parent>
     <groupId>eu.mulk.quarkus-googlecloud-jsonlogging</groupId>
     <artifactId>quarkus-googlecloud-jsonlogging-parent</artifactId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>quarkus-googlecloud-jsonlogging</artifactId>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -14,7 +14,7 @@ SPDX-License-Identifier: LGPL-3.0-or-later
   <parent>
     <groupId>eu.mulk.quarkus-googlecloud-jsonlogging</groupId>
     <artifactId>quarkus-googlecloud-jsonlogging-parent</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>6.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>quarkus-googlecloud-jsonlogging</artifactId>

--- a/runtime/src/main/java/eu/mulk/quarkus/googlecloud/jsonlogging/runtime/package-info.java
+++ b/runtime/src/main/java/eu/mulk/quarkus/googlecloud/jsonlogging/runtime/package-info.java
@@ -43,7 +43,7 @@
  *     <dependency>
  *       <groupId>eu.mulk.quarkus-googlecloud-jsonlogging</groupId>
  *       <artifactId>quarkus-googlecloud-jsonlogging</artifactId>
- *       <version>5.0.0</version>
+ *       <version>6.0.0</version>
  *     </dependency>
  *
  *     ...
@@ -59,7 +59,7 @@
  * dependencies {
  *   // ...
  *
- *   implementation("eu.mulk.quarkus-googlecloud-jsonlogging:quarkus-googlecloud-jsonlogging:5.0.0")
+ *   implementation("eu.mulk.quarkus-googlecloud-jsonlogging:quarkus-googlecloud-jsonlogging:6.0.0")
  *
  *   // ...
  * }


### PR DESCRIPTION
Move to Quarkus 3.x Beta for updating to Jakarta version of the libraries. That means moving away from org.glassfish:java.json to jakarta.json:jakarta.json-api.

The new version will be released as v6.0.0. Any changes should go to both 5.x and 6.x versions until Quarkus 3.x is Final and javax.json is finally history.

Points:
- We might want to change the Import Order to include Jakarta.
- We might want to move from Javax to Jakarta for annotation, ws etc. in the examples.